### PR TITLE
resolve file paths in download and info endpoints

### DIFF
--- a/flask_app/api/v1/files.py
+++ b/flask_app/api/v1/files.py
@@ -78,7 +78,7 @@ def download_dataset_file(dataset_id: uuid.UUID) -> Response:
         if not filepath:
             return APIResponse.not_found("File path not found for dataset")
 
-        file_path = Path(filepath)
+        file_path = Path(filepath).resolve()
         if not file_path.exists():
             return APIResponse.not_found("File does not exist on disk")
 
@@ -148,10 +148,11 @@ def get_file_info(dataset_id: uuid.UUID) -> Response:
             return APIResponse.not_found("Dataset not found")
 
         filepath = document.get("system_result")
+        filepath = Path(filepath).resolve() if filepath else None
         file_info = {
             "dataset_id": str(dataset_id),
-            "filepath": filepath,
-            "exists": Path(filepath).exists() if filepath else False,
+            "filepath": str(filepath) if filepath else None,
+            "exists": filepath.exists() if filepath else False,
             "size": document.get("system_size"),
             "size_hdf5": document.get("system_size_hdf5"),
         }


### PR DESCRIPTION
sometimes system_result contains a string like
"/mnt/ASSAS/upload_datahub/3eb37cd3-792f-425a-9a1a-1a6a23a8bbc3/STUDY/TRANSIENT/BASE_SIMPLIFIED/SBO/SBO_feedbleed/SBO_fb_1300_LIKE_SIMPLIFIED_ASSAS_FILT.bin/../result/dataset.h5" then Path(...).exists() returns False, but Path(...).resolve() will return a valid (and existing!) path.